### PR TITLE
feat: add dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - ✅ Native [ClickHouse](https://clickhouse.com/) support using [`@clickhouse/client`](https://www.npmjs.com/package/@clickhouse/client)
 - ✅ Fully typed CLI (TypeScript)
-- ✅ Supports `migration:create`, `migration:up`, `migration:down`
+- ✅ Supports `migration:create`, `migration:up`, `migration:down`, `dump`
 - ✅ Rollback support using `-- ROLLBACK BELOW --` separator
 - ✅ SHA-256 hash tracking for applied migrations
 - ✅ Enforced one-statement-per-file (recommended)
@@ -59,6 +59,7 @@ npx ch-migrate <command> [options]
 - `migration:create <name> --path=<folder>` – create a timestamped migration file. The `--path` option is optional when the path is defined in `ch-migration.json`.
 - `migration:up --path=<folder>` – apply all pending migrations.
 - `migration:down --file=<filename.sql> --path=<folder>` – roll back a single migration.
+- `dump --out=<file>` – export `CREATE` statements for all tables in the current database. Each statement includes `IF NOT EXISTS` and no `DROP` statements so rerunning is safe.
 
 Each file should contain your SQL up statement followed by `-- ROLLBACK BELOW --` and the down statement. Only one SQL statement per section is enforced.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "migration:create": "ts-node src/cli.ts migration:create",
     "migration:up": "ts-node src/cli.ts migration:up",
     "migration:down": "ts-node src/cli.ts migration:down",
+    "dump": "ts-node src/cli.ts dump",
     "test": "jest"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add `dump` CLI command to export schema with `IF NOT EXISTS`
- document new command and include npm script
- add tests for dump behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eec779e18832788b99eb8bcd56f6f