### PR TITLE
Support CLUSTER placeholder in migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - ✅ SHA-256 hash tracking for applied migrations
 - ✅ Enforced one-statement-per-file (recommended)
 - ✅ Optional config via `ch-migration.json`
+- ✅ `${CLUSTER}` placeholder replaced with the `CLUSTER` environment variable
 
 ---
 


### PR DESCRIPTION
## Summary
- replace `${CLUSTER}` in SQL files with the `CLUSTER` env var before execution and hashing
- document CLUSTER placeholder support
- test cluster placeholder substitution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa32b27c748327998cb00062389d90