### PR TITLE
refactor: shorten ClickHouse env var prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ npm install --save-dev @aragornhq/ch-migration
 
 ## 🔧 Setup
 
-1. Set the ClickHouse connection using environment variables:
+1. Set the ClickHouse connection using environment variables (prefixed with `CH_`):
 
 ```bash
-CLICKHOUSE_HOST=localhost
-CLICKHOUSE_PORT=8123
-CLICKHOUSE_DB=default
-CLICKHOUSE_USER=default
-CLICKHOUSE_PASSWORD=
+CH_HOST=localhost
+CH_PORT=8123
+CH_DB=default
+CH_USER=default
+CH_PASSWORD=
 # set to "true" when using HTTPS
-CLICKHOUSE_USE_TLS=false
+CH_USE_TLS=false
 ```
 
 2. Specify where your migration files live via a `ch-migration.json` file:

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,12 @@
 import { createClient } from '@clickhouse/client';
 
 const options = {
-  host: process.env.CLICKHOUSE_HOST,
-  username: process.env.CLICKHOUSE_USER,
-  password: process.env.CLICKHOUSE_PASSWORD || '',
-  database: process.env.CLICKHOUSE_DB,
-  port: process.env.CLICKHOUSE_PORT,
-  useTls: process.env.CLICKHOUSE_USE_TLS === 'true',
+  host: process.env.CH_HOST,
+  username: process.env.CH_USER,
+  password: process.env.CH_PASSWORD || '',
+  database: process.env.CH_DB,
+  port: process.env.CH_PORT,
+  useTls: process.env.CH_USE_TLS === 'true',
 };
 
 const protocol = options.useTls ? 'https' : 'http';


### PR DESCRIPTION
## Summary
- rename `CLICKHOUSE_` environment variables to `CH_`
- document new `CH_` prefix in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa760025008327a61997852222cb73