### PR TITLE
feat: add replicated migrations table in cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - ✅ Enforced one-statement-per-file (recommended)
 - ✅ Optional config via `ch-migration.json`
 - ✅ `${CH_CLUSTER}` placeholder replaced with the `CH_CLUSTER` environment variable
+- ✅ Uses `ReplicatedReplacingMergeTree` for migration tracking when `CH_CLUSTER` is set
+- ✅ Validates `CREATE TABLE` migrations use `ON CLUSTER` with a `Replicated` engine when `CH_CLUSTER` is set
 
 ---
 


### PR DESCRIPTION
## Summary
- create migrations table with `ReplicatedReplacingMergeTree` when `CH_CLUSTER` is set
- validate `CREATE TABLE` migrations include `ON CLUSTER` and a `Replicated` engine in cluster mode
- document cluster replication requirements and test replicated table creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0d897f3c832780ae66eb900da427