### PR TITLE
Add multi-statement migration support, fix rollback marker parsing, and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - ✅ Optional dry run to validate migrations without applying them
 - ✅ Rollback support using `-- ROLLBACK BELOW --` separator
 - ✅ SHA-256 hash tracking for applied migrations
-- ✅ Enforced one-statement-per-file (recommended)
+- ✅ Supports multiple SQL statements per migration section with ordered rollback
 - ✅ Optional config via `ch-migration.json`
 - ✅ `${CH_CLUSTER}` placeholder replaced with the `CH_CLUSTER` environment variable
 - ✅ Uses `ReplicatedReplacingMergeTree` for migration tracking when `CH_CLUSTER` is set
@@ -67,15 +67,16 @@ npx ch-migrate <command> [options]
 - `migration:down --file=<filename.sql> --path=<folder>` – roll back a single migration.
 - `dump --out=<file>` – export `CREATE` statements for all tables in the current database. Each statement includes `IF NOT EXISTS` and no `DROP` statements so rerunning is safe.
 
-Each file should contain your SQL up statement followed by `-- ROLLBACK BELOW --` and the down statement. Only one SQL statement per section is enforced.
+Each file should contain your SQL up statements followed by `-- ROLLBACK BELOW --` and the down statements. Statements are executed in order; rollbacks run in reverse order.
 
 ```sql
 -- 20250101_create_table.sql
 CREATE TABLE example (id UInt8) ENGINE = MergeTree;
+INSERT INTO example VALUES (1);
 
 -- ROLLBACK BELOW --
+DELETE FROM example WHERE id = 1;
 DROP TABLE example;
 ```
 
 Applied migrations are recorded in a `migrations` table together with a SHA‑256 hash. If a hash changes, the run fails to prevent drift.
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface MigrationFile {
   filename: string;
-  upSql: string;
-  downSql?: string;
+  upSql: string[];
+  downSql?: string[];
   hash: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,113 @@ import path from "path";
 import crypto from "crypto";
 import { MigrationFile } from "./types";
 
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < sql.length; i += 1) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (inLineComment) {
+      current += char;
+      if (char === "\n") {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      current += char;
+      if (char === "*" && next === "/") {
+        current += next;
+        i += 1;
+        inBlockComment = false;
+      }
+      continue;
+    }
+
+    if (inSingle) {
+      current += char;
+      if (char === "'" && sql[i - 1] !== "\\") {
+        inSingle = false;
+      }
+      continue;
+    }
+
+    if (inDouble) {
+      current += char;
+      if (char === '"' && sql[i - 1] !== "\\") {
+        inDouble = false;
+      }
+      continue;
+    }
+
+    if (inBacktick) {
+      current += char;
+      if (char === "`") {
+        inBacktick = false;
+      }
+      continue;
+    }
+
+    if (char === "-" && next === "-") {
+      inLineComment = true;
+      current += char + next;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      current += char + next;
+      i += 1;
+      continue;
+    }
+
+    if (char === "'") {
+      inSingle = true;
+      current += char;
+      continue;
+    }
+
+    if (char === '"') {
+      inDouble = true;
+      current += char;
+      continue;
+    }
+
+    if (char === "`") {
+      inBacktick = true;
+      current += char;
+      continue;
+    }
+
+    if (char === ";") {
+      const trimmed = current.trim();
+      if (trimmed) {
+        statements.push(trimmed);
+      }
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) {
+    statements.push(trimmed);
+  }
+
+  return statements;
+}
+
 export function getMigrationFiles(dir: string): MigrationFile[] {
   return fs
     .readdirSync(dir)
@@ -22,15 +129,17 @@ export function getMigrationFiles(dir: string): MigrationFile[] {
         processed = raw.replace(/\$\{CH_CLUSTER\}/g, cluster);
       }
 
-      const [upSql, downSql] = processed.split(/--\s*ROLLBACK BELOW\s*/i);
+      const [upSql, downSql] = processed.split(
+        /--\s*ROLLBACK BELOW\s*--\s*/i,
+      );
       const hash = crypto
         .createHash("sha256")
         .update(processed)
         .digest("hex");
       return {
         filename,
-        upSql: upSql.trim(),
-        downSql: downSql?.trim(),
+        upSql: splitSqlStatements(upSql),
+        downSql: downSql ? splitSqlStatements(downSql) : undefined,
         hash,
       };
     });


### PR DESCRIPTION
### Motivation
- Allow migration files to contain multiple SQL statements per section so complex changes can be expressed in a single migration and executed in a predictable order. 
- Ensure robust and ordered rollback behavior so partial failures of multi-statement migrations are reverted correctly. 
- Fix parsing of the rollback marker so comment tokens do not leak into parsed down statements.

### Description
- Change the `MigrationFile` shape so `upSql` and `downSql` are `string[]` instead of single strings by updating `src/types.ts`. 
- Add `splitSqlStatements` in `src/utils.ts` to split SQL into ordered statements while respecting single/double/backtick quotes and `--`/`/* */` comments and update `getMigrationFiles` to return arrays and keep the file-level SHA-256 `hash`; also tighten the rollback marker regex to avoid leaking the comment token. 
- Update `src/runner.ts` to validate `CREATE TABLE` `ON CLUSTER`/`Replicated` requirements per statement using `stripLeadingComments`, execute `upSql` statements in order, perform rollbacks of the failing file by running its `downSql` statements in reverse, and roll back previously applied files in reverse order by running their `downSql` arrays in reverse. 
- Update tests in `test/runner.spec.ts` to add multi-statement apply and reverse-rollback tests, adjust mock usage (casting to `jest.Mock`) and update a cluster test expectation to match trimmed statements.

### Testing
- Ran the test suite with `npm test` and all tests passed successfully. 
- New tests covering multi-statement apply ordering and reverse rollback on failure were executed and passed. 
- Existing CLI and runner tests were run and passed during the run (`Test Suites: 2 passed, Tests: 10 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969863a61a08327b824d552a5ffc07c)